### PR TITLE
Respect prefers-dark preferences

### DIFF
--- a/theme/src/components/theme-switcher/theme-switcher.ts
+++ b/theme/src/components/theme-switcher/theme-switcher.ts
@@ -91,8 +91,13 @@ export class ThemeSwitcher extends LitElement {
 		if (localStorageTheme !== null) {
 			this._setTheme(localStorageTheme);
 		} else {
-      this._setTheme('default');
-    }
+			// Set default theme to dark if the operating system specifies this preference
+			if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+				this._setTheme('dark');
+			} else{ // Set to default/light theme if no specification, or light theme is specified
+				this._setTheme('default');
+			}
+    		}
 	}
 
   firstUpdated() {


### PR DESCRIPTION
Adds support for the initial load to pick dark theme if it is specified as a preference in the user OS